### PR TITLE
Adding Support for Property Injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,32 @@ public static class Programm
 		var containerBuilder = new ContainerBuilder();
 		// here you have to pass in the assembly (or assemblies) containing AutoMapper types
 		// stuff like profiles, resolvers and type-converters will be added by this function
-		containerBuilder.AddAutoMapper(typeof(Program).Assembly);
+		containerBuilder.RegisterAutoMapper(typeof(Program).Assembly);
+		
+		var container = containerBuilder.Build();
+
+		var mapper = container.Resolve<IMapper>();
+
+		var customer = new Customer(Guid.NewGuid(), "Google");
+
+		var customerDto = mapper.Map<CustomerDto>(customer);
+	}
+}
+```
+
+### Support for Property Injection
+
+You can set `propertiesAutowired` to true to enable property based injection, just modify the prior example like so:
+
+```csharp
+public static class Programm
+{
+	public static void Main(string args[])
+	{
+		var containerBuilder = new ContainerBuilder();
+		
+		// Update this line with the setting:
+		containerBuilder.RegisterAutoMapper(typeof(Program).Assembly, propertiesAutowired: true);
 		
 		var container = containerBuilder.Build();
 

--- a/src/AutoMapper.Contrib.Autofac.DependencyInjection/ContainerBuilderExtensions.cs
+++ b/src/AutoMapper.Contrib.Autofac.DependencyInjection/ContainerBuilderExtensions.cs
@@ -40,36 +40,36 @@ namespace AutoMapper.Contrib.Autofac.DependencyInjection
             return RegisterAddAutoMapperInternal(builder, new[] {assembly}, configExpression);
         }
         
-        public static ContainerBuilder RegisterAutoMapper(this ContainerBuilder builder, params Assembly[] assemblies)
+        public static ContainerBuilder RegisterAutoMapper(this ContainerBuilder builder, bool propertiesAutowired = false, params Assembly[] assemblies)
         {
-            return RegisterAddAutoMapperInternal(builder, assemblies);
+            return RegisterAddAutoMapperInternal(builder, assemblies, propertiesAutowired: propertiesAutowired);
         }
 
-        public static ContainerBuilder RegisterAutoMapper(this ContainerBuilder builder, Assembly assembly)
+        public static ContainerBuilder RegisterAutoMapper(this ContainerBuilder builder, Assembly assembly, bool propertiesAutowired = false)
         {
-            return RegisterAddAutoMapperInternal(builder, new[] {assembly});
-        }
-
-        public static ContainerBuilder RegisterAutoMapper(this ContainerBuilder builder,
-            Action<IMapperConfigurationExpression> configExpression, params Assembly[] assemblies)
-        {
-            return RegisterAddAutoMapperInternal(builder, assemblies, configExpression);
+            return RegisterAddAutoMapperInternal(builder, new[] {assembly}, propertiesAutowired: propertiesAutowired);
         }
 
         public static ContainerBuilder RegisterAutoMapper(this ContainerBuilder builder,
-            Action<IMapperConfigurationExpression> configExpression, Assembly assembly)
+            Action<IMapperConfigurationExpression> configExpression, bool propertiesAutowired = false, params Assembly[] assemblies)
         {
-            return RegisterAddAutoMapperInternal(builder, new[] {assembly}, configExpression);
+            return RegisterAddAutoMapperInternal(builder, assemblies, configExpression, propertiesAutowired);
+        }
+
+        public static ContainerBuilder RegisterAutoMapper(this ContainerBuilder builder,
+            Action<IMapperConfigurationExpression> configExpression, Assembly assembly, bool propertiesAutowired = false)
+        {
+            return RegisterAddAutoMapperInternal(builder, new[] {assembly}, configExpression, propertiesAutowired);
         }
 
         private static ContainerBuilder RegisterAddAutoMapperInternal(ContainerBuilder builder,
-            IEnumerable<Assembly> assemblies, Action<IMapperConfigurationExpression> configExpression = null)
+            IEnumerable<Assembly> assemblies, Action<IMapperConfigurationExpression> configExpression = null, bool propertiesAutowired = false)
         {
             var usedAssemblies = assemblies as Assembly[] ?? assemblies.ToArray();
 
             var usedConfigExpression = configExpression ?? FallBackExpression;
 
-            builder.RegisterModule(new AutoMapperModule(usedAssemblies, usedConfigExpression));
+            builder.RegisterModule(new AutoMapperModule(usedAssemblies, usedConfigExpression, propertiesAutowired));
 
             return builder;
         }

--- a/test/AutoMapper.Contrib.Autofac.DependencyInjection.Tests/Dtos/NameDto.cs
+++ b/test/AutoMapper.Contrib.Autofac.DependencyInjection.Tests/Dtos/NameDto.cs
@@ -1,0 +1,12 @@
+
+namespace AutoMapper.Contrib.Autofac.DependencyInjection.Tests.Dtos
+{
+    public class NameDto
+    {
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+
+        public bool IsValidFirstName { get; set; }
+    }
+}

--- a/test/AutoMapper.Contrib.Autofac.DependencyInjection.Tests/Entities/Name.cs
+++ b/test/AutoMapper.Contrib.Autofac.DependencyInjection.Tests/Entities/Name.cs
@@ -1,0 +1,9 @@
+namespace AutoMapper.Contrib.Autofac.DependencyInjection.Tests.Entities
+{
+    public class Name
+    {
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+    }
+}

--- a/test/AutoMapper.Contrib.Autofac.DependencyInjection.Tests/Profiles/NameProfile.cs
+++ b/test/AutoMapper.Contrib.Autofac.DependencyInjection.Tests/Profiles/NameProfile.cs
@@ -1,0 +1,15 @@
+using AutoMapper.Contrib.Autofac.DependencyInjection.Tests.Dtos;
+using AutoMapper.Contrib.Autofac.DependencyInjection.Tests.Entities;
+using AutoMapper.Contrib.Autofac.DependencyInjection.Tests.Resolver;
+
+namespace AutoMapper.Contrib.Autofac.DependencyInjection.Tests.Profiles
+{
+    public class NameProfile : Profile
+    {
+        public NameProfile()
+        {
+            CreateMap<Name, NameDto>()
+                .ForMember(destination => destination.IsValidFirstName, options => options.MapFrom<IsFirstNameValidResolver>());
+        }
+    }
+}

--- a/test/AutoMapper.Contrib.Autofac.DependencyInjection.Tests/Resolver/IsFirstNameValidResolver.cs
+++ b/test/AutoMapper.Contrib.Autofac.DependencyInjection.Tests/Resolver/IsFirstNameValidResolver.cs
@@ -1,0 +1,18 @@
+using AutoMapper.Contrib.Autofac.DependencyInjection.Tests.Dtos;
+using AutoMapper.Contrib.Autofac.DependencyInjection.Tests.Entities;
+
+namespace AutoMapper.Contrib.Autofac.DependencyInjection.Tests.Resolver
+{
+    public class IsFirstNameValidResolver : IValueResolver<Name, NameDto, bool>
+    {
+        public TestConfiguration Configuration { get; set; }
+        
+        public bool Resolve(Name source, NameDto destination, bool destMember, ResolutionContext context)
+        {
+            if (source.FirstName != null && source.FirstName.Length <= Configuration.FirstNameCharacterLimit)
+                return true;
+
+            return false;
+        }
+    }
+}

--- a/test/AutoMapper.Contrib.Autofac.DependencyInjection.Tests/TestConfiguration.cs
+++ b/test/AutoMapper.Contrib.Autofac.DependencyInjection.Tests/TestConfiguration.cs
@@ -1,0 +1,6 @@
+namespace AutoMapper.Contrib.Autofac.DependencyInjection.Tests;
+
+public class TestConfiguration
+{
+    public int FirstNameCharacterLimit { get; set; }
+}


### PR DESCRIPTION
Hi,

I could not find any guidelines for contributing to your project, so let me know if I am missing anything 😄 

## Overview

The primary reason for this pull request is to add support for property based injection via Autofac's `PropertiesAutowired` functionality. To read more on that feature they have documentation [here](https://autofac.readthedocs.io/en/latest/register/prop-method-injection.html).

I think the best way to stay backwards compatible would be to add an optional parameter. Which is what I did. The new method signatures look like this, please note this would not break existing code:

```csharp
// One assembly signature:
containerBuilder.RegisterAutoMapper(typeof(Program).Assembly, propertiesAutowired: true);

// Params overload signature:
containerBuilder.RegisterAutoMapper(propertiesAutowired: true, typeof(Program1).Assembly, typeof(Program2).Assembly);

// Configuration overload signature:
containerBuilder.RegisterAutoMapper(cfg => { cfg.AllowNullDestinationValues = true; },
                    typeof(Program).Assembly, propertiesAutowired: true);

// Configuration and params overload signature:
containerBuilder.RegisterAutoMapper(cfg => { cfg.AllowNullDestinationValues = true; },
                    propertiesAutowired: true,  typeof(Program1).Assembly,  typeof(Program2).Assembly);
```

## Files Updated/Added

- `ContainerBuilderExtensions`, here I just added the optional parameter, that is passed down to AutoMapperModule.
- `AutoMapperModule`, after each registration I check if the properties should be autowired and tac that on to the end.
- Test Classes:
    - `Name`, a two property class for mapping
    - `NameDto`, a class with one computed property `IsValidFirstName`
    - `NameProfile`, the mapping setup with the custom value resolver.
    - `IsFirstNameValidResolver`, an example where I have my property based dependency called TestConfiguration.
    - `TestConfiguration`, a class to simulate a dependency from appsettings config.
- `ContainerBuilderExtensionsTests`, Here is where I added all of my new tests and ensured backward compatibility.

## Testing

Three new unit tests were added, basically ensuring that it is, in fact, registering the Custom Value Resolver's property was injected and it's working. These are the new tests:
- ContainerBuilderExtension_PropertiesAutoWiredNotSet_ExpectExceptions
- ContainerBuilderExtension_PropertiesAutoWiredSet_NoExceptionsExpected
- ContainerBuilderExtension_PropertiesAutowired_CustomValueResolverWithPropertyDependencyIsResolved