### PR TITLE
feat: allow calling RegisterAutoMapper multiple times

### DIFF
--- a/AutoMapper.Contrib.Autofac.DependencyInjection.sln
+++ b/AutoMapper.Contrib.Autofac.DependencyInjection.sln
@@ -40,6 +40,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\tag.yml = .github\workflows\tag.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly", "test\AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly\AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly.csproj", "{9772890F-1F2A-4085-AF2B-384DF3ED45E1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -66,6 +68,10 @@ Global
 		{518E0DB7-8C83-41C6-A020-5AF0DFF05F19}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{518E0DB7-8C83-41C6-A020-5AF0DFF05F19}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{518E0DB7-8C83-41C6-A020-5AF0DFF05F19}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9772890F-1F2A-4085-AF2B-384DF3ED45E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9772890F-1F2A-4085-AF2B-384DF3ED45E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9772890F-1F2A-4085-AF2B-384DF3ED45E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9772890F-1F2A-4085-AF2B-384DF3ED45E1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -77,6 +83,7 @@ Global
 		{5EADD7CB-210A-4169-A0DF-C4AE7EDBE731} = {243D0BEA-EA8B-4D7E-B645-BE17B9763896}
 		{518E0DB7-8C83-41C6-A020-5AF0DFF05F19} = {243D0BEA-EA8B-4D7E-B645-BE17B9763896}
 		{1393ACB8-9707-446C-B6FD-4C2513B43592} = {717509EE-6F82-4DCD-9110-B5EEFFDBA678}
+		{9772890F-1F2A-4085-AF2B-384DF3ED45E1} = {7E905FA2-EB17-4082-92C8-244C3933783F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C58D8048-52B6-44D8-AF85-8759A9ED42FA}

--- a/src/AutoMapper.Contrib.Autofac.DependencyInjection/AutoMapper.Contrib.Autofac.DependencyInjection.csproj
+++ b/src/AutoMapper.Contrib.Autofac.DependencyInjection/AutoMapper.Contrib.Autofac.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>7.1.0</Version>
+    <Version>7.2.0-alpha.0</Version>
     <FileVersion>7.1.0.0</FileVersion>
     <Copyright>2022©Sami Al Khatib</Copyright>
     <Authors>Sami Al Khatib</Authors>

--- a/src/AutoMapper.Contrib.Autofac.DependencyInjection/MapperConfigurationExpressionAdapter.cs
+++ b/src/AutoMapper.Contrib.Autofac.DependencyInjection/MapperConfigurationExpressionAdapter.cs
@@ -1,0 +1,11 @@
+namespace AutoMapper.Contrib.Autofac.DependencyInjection;
+
+internal class MapperConfigurationExpressionAdapter
+{
+    public MapperConfigurationExpression MapperConfigurationExpression { get; }
+
+    public MapperConfigurationExpressionAdapter(MapperConfigurationExpression mapperConfigurationExpression)
+    {
+        this.MapperConfigurationExpression = mapperConfigurationExpression;
+    }
+}

--- a/test/AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly/AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly.csproj
+++ b/test/AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly/AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="AutoMapper" Version="12.0.1" />
+    </ItemGroup>
+
+</Project>

--- a/test/AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly/ObjectDestination.cs
+++ b/test/AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly/ObjectDestination.cs
@@ -1,0 +1,6 @@
+namespace AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly;
+
+public class ObjectDestination
+{
+    public string? Id { get; set; }
+}

--- a/test/AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly/ObjectSource.cs
+++ b/test/AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly/ObjectSource.cs
@@ -1,0 +1,6 @@
+namespace AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly;
+
+public class ObjectSource
+{
+    public string? Id { get; set; }
+}

--- a/test/AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly/SecondAssemblyProfile.cs
+++ b/test/AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly/SecondAssemblyProfile.cs
@@ -1,0 +1,9 @@
+﻿namespace AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly;
+
+public class SecondAssemblyProfile : Profile
+{
+    public SecondAssemblyProfile()
+    {
+        this.CreateMap<ObjectSource, ObjectDestination>().ReverseMap();
+    }
+}

--- a/test/AutoMapper.Contrib.Autofac.DependencyInjection.Tests/AutoMapper.Contrib.Autofac.DependencyInjection.Tests.csproj
+++ b/test/AutoMapper.Contrib.Autofac.DependencyInjection.Tests/AutoMapper.Contrib.Autofac.DependencyInjection.Tests.csproj
@@ -22,5 +22,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\AutoMapper.Contrib.Autofac.DependencyInjection\AutoMapper.Contrib.Autofac.DependencyInjection.csproj" />
+    <ProjectReference Include="..\AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly\AutoMapper.Contrib.Autofac.DependencyInjection.SecondAssembly.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Add a wraper for `MapperConfigurationExpression` that can be registered more than once so that we can add the profiles to the configuration multiple times
* Ensure to register specific types only once
* Add tests

Relates to #10 